### PR TITLE
Make sure spock deps aren't exported as they are grails 2.2 specific

### DIFF
--- a/LessResourcesGrailsPlugin.groovy
+++ b/LessResourcesGrailsPlugin.groovy
@@ -1,7 +1,7 @@
 
 class LessResourcesGrailsPlugin {
     // the plugin version
-    def version = "1.3.3.0"
+    def version = "1.3.3.1"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "2.0 > *"
     // the other plugins this plugin depends on

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -28,11 +28,14 @@ grails.project.dependency.resolution = {
 
         test(':spock:0.7') {
             exclude "spock-grails-support"
+            export = false
         }
     }
     dependencies {
         runtime 'org.mozilla:rhino:1.7R4'
 
-        test "org.spockframework:spock-grails-support:0.7-groovy-2.0"
+        test("org.spockframework:spock-grails-support:0.7-groovy-2.0") {
+            export = false
+        }
     }
 }


### PR DESCRIPTION
A small fix to prevent export of the spock dependencies as they seem to break use of the plugin for grails < 2.2 otherwise.
