### PR TITLE
Make plugin compatible with Grails 2.4.4

### DIFF
--- a/LessResourcesGrailsPlugin.groovy
+++ b/LessResourcesGrailsPlugin.groovy
@@ -2,7 +2,7 @@ import org.grails.plugin.resource.CSSPreprocessorResourceMapper
 import org.grails.plugin.resource.CSSRewriterResourceMapper
 
 class LessResourcesGrailsPlugin {
-    def version = "1.3.3.1"
+    def version = "1.3.3.3"
     def grailsVersion = "2.0 > *"
 
     def author = "Karol Balejko"

--- a/application.properties
+++ b/application.properties
@@ -1,1 +1,1 @@
-app.grails.version=2.2.0
+app.grails.version=2.4.4

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -1,10 +1,20 @@
-grails.project.work.dir = 'target'
+grails.project.class.dir = "target/classes"
+grails.project.test.class.dir = "target/test-classes"
+grails.project.test.reports.dir = "target/test-reports"
+grails.project.target.level = 1.6
 
+grails.project.fork = [
+    //  compile: [maxMemory: 256, minMemory: 64, debug: false, maxPerm: 256, daemon:true],
+    test: [maxMemory: 768, minMemory: 64, debug: false, maxPerm: 256, daemon:true],
+    run: [maxMemory: 768, minMemory: 64, debug: false, maxPerm: 256, forkReserve:false],
+    war: [maxMemory: 768, minMemory: 64, debug: false, maxPerm: 256, forkReserve:false],
+    console: [maxMemory: 768, minMemory: 64, debug: false, maxPerm: 256]
+]
+
+grails.project.dependency.resolver = "maven"
 grails.project.dependency.resolution = {
-
-    inherits 'global'
-    log 'warn'
-
+    inherits "global"
+    log "warn"
     repositories {
         grailsCentral()
         mavenLocal()
@@ -12,25 +22,12 @@ grails.project.dependency.resolution = {
     }
 
     dependencies {
-        runtime 'org.mozilla:rhino:1.7R4'
-
-        test("org.spockframework:spock-grails-support:0.7-groovy-2.0") {
-            export = false
-        }
+        runtime 'org.mozilla:rhino:1.7R5'
     }
 
     plugins {
-        runtime ":hibernate:$grailsVersion", {
-            export = false
-        }
-
-        runtime ":resources:1.2.RC2"
-        build(":release:2.2.0", ":rest-client-builder:1.0.3") {
-            export = false
-        }
-
-        test(':spock:0.7') {
-            exclude "spock-grails-support"
+        runtime ":resources:1.2.14"
+        build(":release:3.0.1", ":rest-client-builder:2.0.3") {
             export = false
         }
     }

--- a/grails-app/conf/DataSource.groovy
+++ b/grails-app/conf/DataSource.groovy
@@ -1,32 +1,47 @@
 dataSource {
     pooled = true
+    jmxExport = true
     driverClassName = "org.h2.Driver"
     username = "sa"
     password = ""
 }
 hibernate {
     cache.use_second_level_cache = true
-    cache.use_query_cache = true
-    cache.provider_class = 'net.sf.ehcache.hibernate.EhCacheProvider'
+    cache.use_query_cache = false
+//    cache.region.factory_class = 'net.sf.ehcache.hibernate.EhCacheRegionFactory' // Hibernate 3
+    cache.region.factory_class = 'org.hibernate.cache.ehcache.EhCacheRegionFactory' // Hibernate 4
+    singleSession = true // configure OSIV singleSession mode
+    flush.mode = 'manual' // OSIV session flush mode outside of transactional context
 }
 // environment specific settings
 environments {
     development {
         dataSource {
-            dbCreate = "create-drop" // one of 'create', 'create-drop','update'
-            url = "jdbc:h2:mem:devDB"
+            dbCreate = "create-drop" // one of 'create', 'create-drop', 'update', 'validate', ''
+            url = "jdbc:h2:mem:devDb;MVCC=TRUE"
         }
     }
     test {
         dataSource {
             dbCreate = "update"
-            url = "jdbc:h2:mem:testDb"
+            url = "jdbc:h2:mem:testDb;MVCC=TRUE"
         }
     }
     production {
         dataSource {
             dbCreate = "update"
-            url = "jdbc:h2:file:prodDb;shutdown=true"
+            url = "jdbc:h2:prodDb;MVCC=TRUE"
+            pooled = true
+            properties {
+               maxActive = -1
+               minEvictableIdleTimeMillis=1800000
+               timeBetweenEvictionRunsMillis=1800000
+               numTestsPerEvictionRun=3
+               testOnBorrow=true
+               testWhileIdle=true
+               testOnReturn=true
+               validationQuery="SELECT 1"
+            }
         }
     }
 }

--- a/grails-app/resourceMappers/LessResourceMapper.groovy
+++ b/grails-app/resourceMappers/LessResourceMapper.groovy
@@ -1,4 +1,3 @@
-import org.codehaus.groovy.grails.commons.GrailsApplication
 import org.grails.plugin.resource.mapper.MapperPhase
 
 /**
@@ -11,7 +10,7 @@ class LessResourceMapper {
     static phase = MapperPhase.GENERATION
     static defaultIncludes = [ '**/*.less' ]
 
-    GrailsApplication grailsApplication
+    def grailsApplication
     def lessCompilerService
 
     def paths = [].asSynchronized()
@@ -20,17 +19,22 @@ class LessResourceMapper {
         File lessFile = resource.processedFile
         File cssFile = new File(lessFile.absolutePath + '.css')
 
-        def importPath = grailsApplication.parentContext.getResource(resource.originalUrl)?.file?.parentFile?.absolutePath
+        if(paths.isEmpty()) {
+            addDefaultPath(grailsApplication.config.grails.resources.less.default.importPath ?: ['less'])
+        }
+        def importPath = grailsApplication.mainContext.getResource(resource.originalUrl)?.file?.parentFile?.absolutePath
         if (importPath) {
-            def order = resource.tagAttributes.order ?: 10
-            log.debug "Adding import path [${importPath}][order: ${order}] for resource [${resource}]"
-            paths << [path:importPath, order:order]
-            paths.sort {it.order}
+            if(! paths.find{it.path == importPath}) {
+                def order = resource.tagAttributes.order ?: 10
+                log.debug "Adding import path [${importPath}][order: ${order}] for resource [${resource}]"
+                paths << [path:importPath, order:order]
+                paths.sort {it.order}
+            }
         }
 
         try {
             log.debug "Compiling LESS file [${lessFile}] into [${cssFile}]"
-            lessCompilerService.compile (lessFile, cssFile, paths.collect {it.path})
+            lessCompilerService.compile (lessFile, cssFile, paths*.path)
             resource.processedFile = cssFile
             resource.contentType = 'text/css'
             resource.tagAttributes.rel = 'stylesheet'
@@ -40,4 +44,24 @@ class LessResourceMapper {
         }
     }
 
+    private void addDefaultPath(defaultPath) {
+        def applicationContext = grailsApplication.mainContext
+
+        if(!(defaultPath instanceof Collection)) {
+            defaultPath = [defaultPath]
+        }
+        int order = 1
+        for(path in defaultPath) {
+            def importPath = applicationContext.getResource(path)?.file?.absolutePath
+            if (importPath) {
+                log.debug "Adding default import path [${importPath}][order: ${order}]"
+                if(! paths.find{it.path == importPath}) {
+                    paths << [path: importPath, order: order++]
+                }
+            } else {
+                log.error "Default import path not found: $path"
+            }
+        }
+        paths.sort {it.order}
+    }
 }

--- a/grails-app/services/com/groovydev/LessCompilerService.groovy
+++ b/grails-app/services/com/groovydev/LessCompilerService.groovy
@@ -8,7 +8,7 @@ class LessCompilerService {
     def grailsApplication
 
     private String loadResource(name) {
-        grailsApplication.parentContext.getResource("classpath:${name}").file.text
+        grailsApplication.mainContext.getResource("classpath:${name}").file.text
     }
 
     def compile(source, target, paths = []) {

--- a/test/integration/com/groovydev/LessCompilerServiceSpec.groovy
+++ b/test/integration/com/groovydev/LessCompilerServiceSpec.groovy
@@ -1,11 +1,10 @@
 package com.groovydev
 
-import grails.plugin.spock.IntegrationSpec
+import grails.test.spock.IntegrationSpec
 import spock.lang.Unroll
 
 class LessCompilerServiceSpec extends IntegrationSpec {
 
-    def grailsApplication
     def lessCompilerService
 
     @Unroll
@@ -13,8 +12,8 @@ class LessCompilerServiceSpec extends IntegrationSpec {
         when:
         def tmpTarget = File.createTempFile("LessCompilerServiceSpec", ".css")
         tmpTarget.deleteOnExit()
-        def srcFile = grailsApplication.parentContext.getResource(srcLessFile)?.file
-        def modelFile = grailsApplication.parentContext.getResource(modelCssFile)?.file
+        def srcFile = new File("test/integration", srcLessFile)
+        def modelFile = new File("test/integration", modelCssFile)
         def importPath = srcFile?.parentFile?.absolutePath
         lessCompilerService.compile(srcFile, tmpTarget, [importPath])
 


### PR DESCRIPTION
I know this plugin is deprecated but I still use it in quite a few GR8 CRM plugins. Can you please consider this pull request and release a version of the navigation plugin that work with Grails 2.4.4?

This pull request also includes a new feature to configure default import paths. This is needed to be able to control the import order of less files.

If you don't want to be a maintainer anymore I volunteer to take over ownership of this plugin.

I will take a look at asset-pipeline plugin and see if I can migrate to that, but I would be nice to get the less-resources plugin working for old projects that are waiting to be upgraded to Grails 2.4.4 without major migrations.
